### PR TITLE
Change Slack adapter URL preg_match pattern

### DIFF
--- a/src/Adapters/Slack/Adapter.php
+++ b/src/Adapters/Slack/Adapter.php
@@ -89,6 +89,6 @@ class Adapter extends \Reflar\Webhooks\Adapters\Adapter
      */
     public static function isValidURL(string $url): bool
     {
-        return preg_match('/^https?:\/\/hooks\.slack\.com\/services\/T[A-Z0-9]+\/B[A-Z0-9]+\/.{24}$/', $url);
+        return preg_match('/^https?:\/\/hooks\.slack\.com\/services\/T.{8,}\/B.{8,}\/.{24}$/', $url);
     }
 }

--- a/src/Adapters/Slack/Adapter.php
+++ b/src/Adapters/Slack/Adapter.php
@@ -89,6 +89,6 @@ class Adapter extends \Reflar\Webhooks\Adapters\Adapter
      */
     public static function isValidURL(string $url): bool
     {
-        return preg_match('/^https?:\/\/hooks\.slack\.com\/services\/.{9}\/.{9}\/.{24}$/', $url);
+        return preg_match('/^https?:\/\/hooks\.slack\.com\/services\/T[A-Z0-9]+\/B[A-Z0-9]+\/.{24}$/', $url);
     }
 }


### PR DESCRIPTION
…cters. Slack URLs second subpattern can contain at least 11 characters. This future proofs for any length.