### PR TITLE
[2.x] Update to opis/closure v4 and fix PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "guzzlehttp/guzzle": "7.*",
         "ssnepenthe/color-utils": "^0.4.2",
         "html2text/html2text": "^4.3.1",
-        "charescape/serialize-closure": "^3.8"
+        "opis/closure": "^4.5.0"
     },
     "replace": {
         "reflar/webhooks": "*"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,5 +9,5 @@ parameters:
     - src
   excludePaths:
     - *.blade.php
-  checkMissingIterableValueType: false
+  # checkMissingIterableValueType: false
   databaseMigrationsPath: ['migrations']

--- a/src/Adapters/Adapter.php
+++ b/src/Adapters/Adapter.php
@@ -83,7 +83,7 @@ abstract class Adapter
                 $e
             );
         } catch (Throwable $e) {
-            $handled = $e instanceof $this->exception;
+            $handled = $this->exception && $e instanceof $this->exception;
 
             TriggerListener::debug(get_class($response->event).": webhook $webhook->id --> other error");
 
@@ -185,7 +185,7 @@ abstract class Adapter
         );
 
         // Use reporters (e.g. Sentry) if it's an "unhandled" exception
-        if (!($e instanceof $this->exception)) {
+        if (!$this->exception || !($e instanceof $this->exception)) {
             /** @var Reporter[] $reporters */
             $reporters = Container::getInstance()->tagged(Reporter::class);
 

--- a/src/Jobs/HandleEvent.php
+++ b/src/Jobs/HandleEvent.php
@@ -30,7 +30,7 @@ class HandleEvent implements ShouldQueue
 
     public function __construct(protected $name, protected $event)
     {
-        # Make the unserializer compatible with v3 data to continue working with queued jobs created before the upgrade.
+        // Make the unserializer compatible with v3 data to continue working with queued jobs created before the upgrade.
         \Opis\Closure\init(null, true);
     }
 

--- a/src/Jobs/HandleEvent.php
+++ b/src/Jobs/HandleEvent.php
@@ -30,6 +30,8 @@ class HandleEvent implements ShouldQueue
 
     public function __construct(protected $name, protected $event)
     {
+        # Make the unserializer compatible with v3 data to continue working with queued jobs created before the upgrade.
+        \Opis\Closure\init(null, true);
     }
 
     /**


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Replace the closure package, which itself provided more modern support for opis/closure back in the day, with the original package that supports PHP 8.0-8.5. The old one had not been updated in 3+ years.

  ```
  PHP Deprecated:  Opis\Closure\unserialize(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead in [vendor]/charescape\serialize-closure\functions.php
  ```
 
  There was a package rewrite with v4, but this only affects the _data_ unserializing, and there's a v3 compatibility mode I enabled in case a queued job was created before the upgrade -- though not sure if we should really support this use case anyways. Unsure of what the harm on enabling the compat mode is.
- Update PHPStan config so that it works again after major upgrade in flarum/phpstan package

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).
