### PR TITLE
fix(tags): allow webhooks to trigger when any matching tag is present

### DIFF
--- a/src/Actions/Discussion/Action.php
+++ b/src/Actions/Discussion/Action.php
@@ -41,7 +41,6 @@ abstract class Action extends \FoF\Webhooks\Action
         $tagIds = $webhook->tag_id;
         $tagsIsEnabled = resolve(ExtensionManager::class)->isEnabled('flarum-tags');
 
-        /** @phpstan-ignore-next-line */
-        return !empty($tagIds) && $tagsIsEnabled && !$discussion->tags()->whereIn('id', $webhook->tag_id)->exists();
+        return !empty($tagIds) && $tagsIsEnabled && !$webhook->hasMatchingTags($discussion);
     }
 }

--- a/src/Actions/Post/Action.php
+++ b/src/Actions/Post/Action.php
@@ -32,6 +32,6 @@ abstract class Action extends \FoF\Webhooks\Action
         $tagIds = $webhook->tag_id;
         $tagsIsEnabled = resolve(ExtensionManager::class)->isEnabled('flarum-tags');
 
-        return $discussion && !empty($tagIds) && $tagsIsEnabled && !$discussion->tags()->whereIn('id', $tagIds)->exists();
+        return $discussion && !empty($tagIds) && $tagsIsEnabled && !$webhook->hasMatchingTags($discussion);
     }
 }

--- a/src/Models/Webhook.php
+++ b/src/Models/Webhook.php
@@ -12,6 +12,7 @@
 namespace FoF\Webhooks\Models;
 
 use Flarum\Database\AbstractModel;
+use Flarum\Discussion\Discussion;
 use Flarum\Group\Group;
 use Flarum\Tags\Tag;
 use FoF\Webhooks\Adapters\Adapters;
@@ -68,6 +69,10 @@ class Webhook extends AbstractModel
         return isset($adapter) && $adapter::isValidURL($this->url);
     }
 
+    protected $casts = [
+        'tag_id' => 'array',
+    ];
+
     public function group(): BelongsTo
     {
         return $this->belongsTo(Group::class);
@@ -76,6 +81,22 @@ class Webhook extends AbstractModel
     public function appliedTags(): array
     {
         return Tag::query()->select('name')->whereIn('id', $this->tag_id)->pluck('name')->toArray();
+    }
+
+    public function hasMatchingTags(Discussion $discussion): bool
+    {
+        if (empty($this->tag_id)) {
+            return true;
+        }
+
+        return $discussion->tags()->whereIn('id', $this->tag_id)->exists();
+    }
+
+    public function setTagIdAttribute($value): void
+    {
+        $this->attributes['tag_id'] = is_array($value)
+            ? json_encode($value, JSON_THROW_ON_ERROR)
+            : $value;
     }
 
     public function getIncludeTags(): bool


### PR DESCRIPTION
**Fixes:**
Fixes the webhook tag matching bug where a discussion/post with multiple tags did not trigger a webhook when only one configured tag matched.

**Changes proposed in this pull request:**
Added Webhook::hasMatchingTags() to centralize matching logic.
Cast tag_id as an array and ensure JSON array storage for webhook tag selection.
Updated Action.php and Action.php so webhooks are not ignored when at least one configured tag matches.

**Reviewers should focus on:**
Correctness of the new hasMatchingTags() behavior
tag_id storage and retrieval for both numeric and JSON payloads
No unintended impact on webhooks without tag filtering


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
