### PR TITLE
[1.x] fix: handle null post in getContent method to prevent errors

### DIFF
--- a/src/Helpers/Post.php
+++ b/src/Helpers/Post.php
@@ -18,13 +18,23 @@ use Html2Text\Html2Text;
 class Post
 {
     /**
-     * @param \Flarum\Post\Post $post
-     * @param Webhook|null      $webhook
+     * @param \Flarum\Post\Post|null $post
+     * @param Webhook|null $webhook
      *
      * @return string|null
      */
-    public static function getContent(\Flarum\Post\Post $post, ?Webhook $webhook = null): ?string
+    public static function getContent(?\Flarum\Post\Post $post, ?Webhook $webhook = null): ?string
     {
+        /*
+         * If no post is provided, return null.
+         * Behavior with other extensions can sometimes cause posts passed (e.g. discussion's first post) to be null.
+         * We don't want to ignore the event entirely, so we'll return empty content instead.
+         * This is implemented here to avoid duplicate checks.
+         */
+        if (!$post) {
+            return null;
+        }
+
         $content = $post->content;
 
         if (isset($webhook) && $post instanceof CommentPost) {

--- a/src/Helpers/Post.php
+++ b/src/Helpers/Post.php
@@ -19,7 +19,7 @@ class Post
 {
     /**
      * @param \Flarum\Post\Post|null $post
-     * @param Webhook|null $webhook
+     * @param Webhook|null           $webhook
      *
      * @return string|null
      */


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes https://discuss.flarum.org/d/17812-friendsofflarum-webhooks/288**

**Changes proposed in this pull request:**
Don't error if no post passed to the helper. This is more of a bandaid, but I was not able to reproduce the original error with Byobu.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- ~~Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)~~
