### PR TITLE
[2.x] Make tag_id nullable and forward-port null post parameter 

### DIFF
--- a/migrations/2026_05_24_fix_tag_id_nullable.php
+++ b/migrations/2026_05_24_fix_tag_id_nullable.php
@@ -24,4 +24,3 @@ return [
         // noop
     },
 ];
-

--- a/migrations/2026_05_24_fix_tag_id_nullable.php
+++ b/migrations/2026_05_24_fix_tag_id_nullable.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of fof/webhooks.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+// Fixes the tag_id column to ensure it remains nullable after the JSON conversion.
+// Looks like some DB backends allow NULL (e.g. MySQL 8.4.2) on JSON fields while other's don't unless explicitly set.
+return [
+    'up' => static function (Builder $schema) {
+        $schema->table('webhooks', function (Blueprint $table) {
+            $table->json('tag_id')->nullable()->change();
+        });
+    },
+    'down' => static function (Builder $schema) {
+        // noop
+    },
+];
+

--- a/src/Helpers/Post.php
+++ b/src/Helpers/Post.php
@@ -18,13 +18,17 @@ use Html2Text\Html2Text;
 class Post
 {
     /**
-     * @param \Flarum\Post\Post $post
-     * @param Webhook|null      $webhook
+     * @param \Flarum\Post\Post|null $post
+     * @param Webhook|null $webhook
      *
      * @return string|null
      */
-    public static function getContent(\Flarum\Post\Post $post, ?Webhook $webhook = null): ?string
+    public static function getContent(?\Flarum\Post\Post $post, ?Webhook $webhook = null): ?string
     {
+        if (!$post) {
+            return null;
+        }
+
         $content = $post->content;
 
         if (isset($webhook) && $post instanceof CommentPost) {

--- a/src/Helpers/Post.php
+++ b/src/Helpers/Post.php
@@ -19,7 +19,7 @@ class Post
 {
     /**
      * @param \Flarum\Post\Post|null $post
-     * @param Webhook|null $webhook
+     * @param Webhook|null           $webhook
      *
      * @return string|null
      */


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
- fix: allow null post parameter in getContent method to prevent errors (forwardport from 1.x)
- fix: ensure tag_id column remains nullable after JSON conversion

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).
