### PR TITLE
[1.x] fix: ensure tag_id column remains nullable after JSON conversion

### DIFF
--- a/migrations/2026_05_24_fix_tag_id_nullable.php
+++ b/migrations/2026_05_24_fix_tag_id_nullable.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of fof/webhooks.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+// Fixes the tag_id column to ensure it remains nullable after the JSON conversion.
+// Looks like some DB backends allow NULL (e.g. MySQL 8.4.2) on JSON fields while other's don't unless explicitly set.
+return [
+    'up' => static function (Builder $schema) {
+        $schema->table('webhooks', function (Blueprint $table) {
+            $table->json('tag_id')->nullable()->change();
+        });
+    },
+    'down' => static function (Builder $schema) {
+        // noop
+    },
+];


### PR DESCRIPTION
This was not caught because some DB backends (eg. MySQL 8.4.2) seem to allow NULL in the JSON field even if it's not marked as nullable. We want to explicitly allow this.

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Backport https://github.com/FriendsOfFlarum/webhooks/pull/86/commits/08ee7836ba2c7b53ff0cabe2a37a69aed1c0945b

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).
